### PR TITLE
Hide error definitions under the interface

### DIFF
--- a/crates/zksync-error-codegen/src/codegen/rust/files/error/mod_file.rs
+++ b/crates/zksync-error-codegen/src/codegen/rust/files/error/mod_file.rs
@@ -37,8 +37,8 @@ impl RustBackend {
         let result = quote! {
 
 
-            pub mod definitions;
-            pub mod domains;
+            pub(crate) mod definitions;
+            pub(crate) mod domains;
 
             use std::error::Error;
             use crate::identifier::Identifier;


### PR DESCRIPTION
Now accessing error definitions and codes is only possible through `domain_identifier::component_identifier::<name>` path in `zksync_error` crate; the actual definitions are hidden from outside the crate.