### PR TITLE
feat: harmonize interfaces across hierarchy

### DIFF
--- a/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
@@ -146,7 +146,7 @@ impl RustBackend {
                 }
                 impl std::fmt::Display for #component_name {
                     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        f.write_fmt(format_args!("{self:?}"))
+                        f.write_str(&self.get_message())
                     }
                 }
                 impl Documented for #component_name {


### PR DESCRIPTION
- Allows throwing domain/component errors. Now you can call `get_documentation` and use `Display` on anything
- Harmonize `std::fmt::Display` across hierarchy (always displays message)