### PR TITLE
Support types from zksync_types

### DIFF
--- a/crates/zksync-error-codegen/src/backend/rust/files/cargo.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/cargo.rs
@@ -34,7 +34,7 @@ strum = "0.26.3"
 strum_macros = "0.26.4"
 
 # Required for types such as H160, H256, and U256.
-zksync_types = {{ git = "https://github.com/matter-labs/zksync-era", tag = "core-v26.4.0" }}
+zksync_basic_types = {{ git = "https://github.com/matter-labs/zksync-era", tag = "core-v26.4.0" }}
 
 zksync-error-description = {{ git = "{}", branch = "main"}}
 {import_anyhow}

--- a/crates/zksync-error-codegen/src/backend/rust/files/cargo.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/cargo.rs
@@ -32,6 +32,10 @@ serde = {{ version = "1.0.210", features = [ "derive", "rc" ] }}
 serde_json = "1.0.128"
 strum = "0.26.3"
 strum_macros = "0.26.4"
+
+# Required for types such as H160, H256, and U256.
+zksync_types = {{ git = "https://github.com/matter-labs/zksync-era", tag = "core-v26.4.0" }}
+
 zksync-error-description = {{ git = "{}", branch = "main"}}
 {import_anyhow}
 "#,

--- a/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
@@ -6,6 +6,7 @@ use zksync_error_model::inner::ComponentDescription;
 use crate::backend::rust::error::GenerationError;
 use crate::backend::rust::util::codegen::doc_tokens;
 use crate::backend::rust::util::codegen::ident;
+use crate::backend::rust::util::codegen::type_ident;
 use crate::backend::rust::RustBackend;
 use crate::backend::File;
 use zksync_error_model::inner::ErrorDescription;
@@ -51,7 +52,7 @@ impl RustBackend {
         let mut field_tokens = Vec::new();
         for FieldDescription { name, r#type } in fields {
             let name = ident(name);
-            let typ = ident(&self.get_rust_type(r#type)?);
+            let typ = type_ident(&self.get_rust_type(r#type)?);
             field_tokens.push(quote! { #name : #typ  });
         }
         let error_name = RustBackend::error_ident(error);

--- a/crates/zksync-error-codegen/src/backend/rust/mod.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/mod.rs
@@ -8,6 +8,7 @@ use error::GenerationError;
 use proc_macro2::TokenStream;
 use util::codegen::ident;
 use util::codegen::sanitize;
+use util::codegen::type_ident;
 use zksync_error_model::inner::ComponentMetadata;
 use zksync_error_model::inner::DomainMetadata;
 use zksync_error_model::unpacked::UnpackedModel;
@@ -104,10 +105,11 @@ impl RustBackend {
     }
     fn type_as_rust(typ: &FullyQualifiedTargetLanguageType) -> String {
         let FullyQualifiedTargetLanguageType { name, path } = typ;
+        let name = sanitize(name);
         if path.is_empty() {
-            name.to_string()
+            name
         } else {
-            format!("{path}.{name}")
+            format!("{path}::{name}")
         }
     }
 
@@ -147,19 +149,19 @@ impl RustBackend {
         Ok(format!("{name}Code"))
     }
     fn domain_code_ident(domain: &DomainMetadata) -> TokenStream {
-        ident(&Self::domain_code_type_name(domain).expect("Internal error"))
+        type_ident(&Self::domain_code_type_name(domain).expect("Internal error"))
     }
     fn domain_ident(domain: &DomainMetadata) -> TokenStream {
-        ident(&Self::domain_type_name(domain).expect("Internal error"))
+        type_ident(&Self::domain_type_name(domain).expect("Internal error"))
     }
     fn component_code_ident(component: &ComponentMetadata) -> TokenStream {
-        ident(&Self::component_code_type_name(component).expect("Internal error"))
+        type_ident(&Self::component_code_type_name(component).expect("Internal error"))
     }
     fn component_ident(component: &ComponentMetadata) -> TokenStream {
-        ident(&Self::component_type_name(component).expect("Internal error"))
+        type_ident(&Self::component_type_name(component).expect("Internal error"))
     }
     fn component_error_alias_ident(component: &ComponentMetadata) -> TokenStream {
-        ident(&format!(
+        type_ident(&format!(
             "{}Error",
             &Self::component_type_name(component).expect("Internal error")
         ))

--- a/crates/zksync-error-codegen/src/backend/rust/util/codegen.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/util/codegen.rs
@@ -17,6 +17,11 @@ pub struct ComponentContext {
     pub component_code: TokenStream,
 }
 
+pub fn type_ident(name: &str) -> TokenStream {
+    name.parse()
+        .unwrap_or_else(|_| panic!("Unable to parse Rust expression: {name}"))
+}
+
 pub fn ident(name: &str) -> TokenStream {
     sanitize(name)
         .parse()

--- a/zksync-root.json
+++ b/zksync-root.json
@@ -38,7 +38,7 @@
             "bindings": {
                 "rust": {
                     "name": "H160",
-                    "path": "zksync_types"
+                    "path": "zksync_basic_types"
                 }
             }
         },
@@ -48,7 +48,7 @@
             "bindings": {
                 "rust": {
                     "name": "H256",
-                    "path": "zksync_types"
+                    "path": "zksync_basic_types"
                 }
             }
         },
@@ -58,7 +58,7 @@
             "bindings": {
                 "rust": {
                     "name": "U256",
-                    "path": "zksync_types"
+                    "path": "zksync_basic_types"
                 }
             }
         },

--- a/zksync-root.json
+++ b/zksync-root.json
@@ -33,6 +33,36 @@
             }
         },
         {
+            "name": "H160",
+            "description": "160-bit hash",
+            "bindings": {
+                "rust": {
+                    "name": "H160",
+                    "path": "zksync_types"
+                }
+            }
+        },
+        {
+            "name": "H256",
+            "description": "256-bit hash",
+            "bindings": {
+                "rust": {
+                    "name": "H256",
+                    "path": "zksync_types"
+                }
+            }
+        },
+        {
+            "name": "U256",
+            "description": "256-bit unsigned integer",
+            "bindings": {
+                "rust": {
+                    "name": "U256",
+                    "path": "zksync_types"
+                }
+            }
+        },
+        {
             "name": "map",
             "description": "String to string mapping.",
             "bindings": {


### PR DESCRIPTION
Allows using types H256, U256, H160 in the error fields