### PR TITLE
feat: support u64 types in error database

### DIFF
--- a/zksync-root.json
+++ b/zksync-root.json
@@ -48,6 +48,15 @@
             }
         },
         {
+            "name": "u64",
+            "description": "64-bit unsigned integer",
+            "bindings": {
+                "rust": {
+                    "expression": "zksync_basic_types::U64"
+                }
+            }
+        },
+        {
             "name": "U256",
             "description": "256-bit unsigned integer",
             "bindings": {


### PR DESCRIPTION
Example of u64 usage are timestamps in blocks.