### PR TITLE
Support overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2570,7 @@ dependencies = [
 name = "zksync-error-model"
 version = "0.1.0"
 dependencies = [
+ "const_format",
  "derive_more",
  "serde",
  "thiserror 2.0.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,8 @@ name = "zksync-error-codegen-cli"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "serde_json",
+ "thiserror 2.0.12",
  "zksync-error-codegen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ version = "0.1.0"
 
 cargo_metadata = "0.19.2"
 clap = { version = "4.5.21", features = ["derive", "string"] }
+const_format = "0.2.34"
 derive_more = { version = "2.0.0", features = ["display"] }
 include_dir = "0.7.4"
 maplit = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde_json_path_to_error = "0.1.4"
 strum = "0.27.1"
 strum_macros = "0.27.1"
 tera = "1.20.0"
-thiserror = "2.0.12"
+thiserror = "2"
 
 #########################
 # Local dependencies    #

--- a/crates/zksync-error-codegen-cli/Cargo.toml
+++ b/crates/zksync-error-codegen-cli/Cargo.toml
@@ -12,6 +12,8 @@ edition.workspace = true
 # External dependencies #
 #########################
 
+serde_json.workspace = true
+thiserror.workspace = true
 clap.workspace = true
 
 #########################

--- a/crates/zksync-error-codegen-cli/src/arguments/conversion.rs
+++ b/crates/zksync-error-codegen-cli/src/arguments/conversion.rs
@@ -1,26 +1,44 @@
+use std::collections::BTreeMap;
+
 use zksync_error_codegen::arguments::BackendOutput;
+
+use crate::error::ApplicationError;
 
 use super::Arguments;
 
-impl From<Arguments> for zksync_error_codegen::arguments::GenerationArguments {
-    fn from(val: Arguments) -> Self {
+impl TryFrom<Arguments> for zksync_error_codegen::arguments::GenerationArguments {
+    type Error = ApplicationError;
+
+    fn try_from(value: Arguments) -> Result<Self, Self::Error> {
         let Arguments {
-            root: definitions,
+            sources,
             backend,
             verbose,
             output_directory,
-            additional_definition_files: additional_inputs,
             backend_args,
-        } = val;
-        zksync_error_codegen::arguments::GenerationArguments {
+            remap,
+        } = value;
+
+        let override_map: BTreeMap<String, String> = {
+            if let Some(remap) = remap {
+                serde_json::from_str(&remap).map_err(|e| ApplicationError::InvalidArgument {
+                    argument: remap,
+                    reason: e.to_string(),
+                })?
+            } else {
+                Default::default()
+            }
+        };
+
+        Ok(zksync_error_codegen::arguments::GenerationArguments {
             verbose,
-            root_link: definitions,
+            input_links: sources,
+            override_links: override_map.into_iter().collect(),
             outputs: vec![BackendOutput {
                 output_path: output_directory.into(),
                 backend: backend.into(),
                 arguments: backend_args.into_iter().collect(),
             }],
-            input_links: additional_inputs,
-        }
+        })
     }
 }

--- a/crates/zksync-error-codegen-cli/src/arguments/mod.rs
+++ b/crates/zksync-error-codegen-cli/src/arguments/mod.rs
@@ -18,13 +18,9 @@ pub use backend::Backend;
     long_about = "Generator of the error handling code in ZKsync components."
 )]
 pub struct Arguments {
-    /// Link to the master JSON file.
-    #[arg(long = "root-definitions")]
-    pub root: String,
-
-    /// Links to additional JSON file.
-    #[arg(long = "additional-definitions")]
-    pub additional_definition_files: Vec<String>,
+    /// Source JSON file. Should be repeated for every file.
+    #[arg(long = "source")]
+    pub sources: Vec<String>,
 
     /// Selected backend.
     #[arg(short = 'b',
@@ -48,6 +44,10 @@ pub struct Arguments {
         value_parser(parse_key_val)
     )]
     pub backend_args: Vec<(String, String)>,
+
+    /// Remap links. Accepts a JSON.
+    #[arg(long = "remap")]
+    pub remap: Option<String>,
 }
 
 ///

--- a/crates/zksync-error-codegen-cli/src/error.rs
+++ b/crates/zksync-error-codegen-cli/src/error.rs
@@ -1,0 +1,9 @@
+use zksync_error_codegen::error::ProgramError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ApplicationError {
+    #[error("Invalid argument `{argument}`: {reason}")]
+    InvalidArgument { argument: String, reason: String },
+    #[error(transparent)]
+    ProgramError(#[from] ProgramError),
+}

--- a/crates/zksync-error-codegen-cli/src/main.rs
+++ b/crates/zksync-error-codegen-cli/src/main.rs
@@ -1,14 +1,15 @@
 pub mod arguments;
+pub mod error;
 
 use clap::Parser;
 
 use arguments::Arguments;
 
-use zksync_error_codegen::error::ProgramError;
+use error::ApplicationError;
 use zksync_error_codegen::load_and_generate;
 
-fn main_inner(arguments: Arguments) -> Result<(), ProgramError> {
-    load_and_generate(arguments.into())
+fn main_inner(arguments: Arguments) -> Result<(), ApplicationError> {
+    Ok(load_and_generate(arguments.try_into()?)?)
 }
 
 fn main() {

--- a/crates/zksync-error-codegen/src/arguments.rs
+++ b/crates/zksync-error-codegen/src/arguments.rs
@@ -8,8 +8,8 @@ pub struct BackendOutput {
 
 pub struct GenerationArguments {
     pub verbose: bool,
-    pub root_link: String,
     pub input_links: Vec<String>,
+    pub override_links: Vec<(String, String)>,
     pub outputs: Vec<BackendOutput>,
 }
 

--- a/crates/zksync-error-codegen/src/backend/mdbook/config.rs
+++ b/crates/zksync-error-codegen/src/backend/mdbook/config.rs
@@ -1,5 +1,5 @@
-use crate::backend::arguments::ArgumentError;
 use crate::backend::IBackendConfig;
+use crate::backend::arguments::ArgumentError;
 
 #[derive(Default)]
 pub struct MDBookBackendConfig;

--- a/crates/zksync-error-codegen/src/backend/mdbook/mod.rs
+++ b/crates/zksync-error-codegen/src/backend/mdbook/mod.rs
@@ -13,8 +13,8 @@ use super::File;
 
 use include_dir::include_dir;
 use zksync_error_model::inner::Model;
-use zksync_error_model::unpacked::flatten;
 use zksync_error_model::unpacked::UnpackedModel;
+use zksync_error_model::unpacked::flatten;
 
 pub struct MDBookBackend {
     _config: MDBookBackendConfig,

--- a/crates/zksync-error-codegen/src/backend/rust/config.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/config.rs
@@ -1,6 +1,6 @@
-use crate::backend::arguments::parse_bool;
-use crate::backend::arguments::ArgumentError;
 use crate::backend::IBackendConfig;
+use crate::backend::arguments::ArgumentError;
+use crate::backend::arguments::parse_bool;
 
 pub struct Config {
     pub use_anyhow: bool,

--- a/crates/zksync-error-codegen/src/backend/rust/files/cargo.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/cargo.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
+use crate::backend::File;
 use crate::backend::rust::error::GenerationError;
 use crate::backend::rust::{RustBackend, RustBackendConfig};
-use crate::backend::File;
 
 impl RustBackend {
     pub fn generate_file_cargo(&mut self) -> Result<Option<File>, GenerationError> {

--- a/crates/zksync-error-codegen/src/backend/rust/files/documentation.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/documentation.rs
@@ -1,9 +1,9 @@
 use quote::quote;
 use std::path::PathBuf;
 
-use crate::backend::rust::error::GenerationError;
-use crate::backend::rust::RustBackend;
 use crate::backend::File;
+use crate::backend::rust::RustBackend;
+use crate::backend::rust::error::GenerationError;
 
 impl RustBackend {
     pub fn generate_file_documentation(&mut self) -> Result<File, GenerationError> {

--- a/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
@@ -3,12 +3,12 @@ use quote::quote;
 use std::path::PathBuf;
 use zksync_error_model::inner::ComponentDescription;
 
+use crate::backend::File;
+use crate::backend::rust::RustBackend;
 use crate::backend::rust::error::GenerationError;
 use crate::backend::rust::util::codegen::doc_tokens;
 use crate::backend::rust::util::codegen::ident;
 use crate::backend::rust::util::codegen::type_ident;
-use crate::backend::rust::RustBackend;
-use crate::backend::File;
 use zksync_error_model::inner::ErrorDescription;
 use zksync_error_model::inner::ErrorDocumentation;
 use zksync_error_model::inner::FieldDescription;

--- a/crates/zksync-error-codegen/src/backend/rust/files/error/domains.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/error/domains.rs
@@ -1,13 +1,13 @@
 use quote::quote;
 use std::path::PathBuf;
 
+use crate::backend::File;
+use crate::backend::rust::RustBackend;
 use crate::backend::rust::error::GenerationError;
-use crate::backend::rust::util::codegen::map_components;
-use crate::backend::rust::util::codegen::map_domains;
 use crate::backend::rust::util::codegen::ComponentContext;
 use crate::backend::rust::util::codegen::DomainContext;
-use crate::backend::rust::RustBackend;
-use crate::backend::File;
+use crate::backend::rust::util::codegen::map_components;
+use crate::backend::rust::util::codegen::map_domains;
 
 impl RustBackend {
     pub fn generate_file_error_domains(&mut self) -> Result<File, GenerationError> {

--- a/crates/zksync-error-codegen/src/backend/rust/files/error/mod_file.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/error/mod_file.rs
@@ -1,9 +1,9 @@
 use quote::quote;
 use std::path::PathBuf;
 
-use crate::backend::rust::error::GenerationError;
-use crate::backend::rust::RustBackend;
 use crate::backend::File;
+use crate::backend::rust::RustBackend;
+use crate::backend::rust::error::GenerationError;
 
 impl RustBackend {
     pub fn generate_file_error_mod(&mut self) -> Result<File, GenerationError> {

--- a/crates/zksync-error-codegen/src/backend/rust/files/identifier.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/identifier.rs
@@ -1,9 +1,9 @@
 use quote::quote;
 use std::path::PathBuf;
 
-use crate::backend::rust::error::GenerationError;
-use crate::backend::rust::RustBackend;
 use crate::backend::File;
+use crate::backend::rust::RustBackend;
+use crate::backend::rust::error::GenerationError;
 
 impl RustBackend {
     pub fn generate_file_identifier(&mut self) -> Result<File, GenerationError> {

--- a/crates/zksync-error-codegen/src/backend/rust/files/kind.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/kind.rs
@@ -1,9 +1,9 @@
 use quote::quote;
 use std::path::PathBuf;
 
-use crate::backend::rust::error::GenerationError;
-use crate::backend::rust::RustBackend;
 use crate::backend::File;
+use crate::backend::rust::RustBackend;
+use crate::backend::rust::error::GenerationError;
 
 impl RustBackend {
     pub fn generate_file_kind(&mut self) -> Result<File, GenerationError> {

--- a/crates/zksync-error-codegen/src/backend/rust/files/lib.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/lib.rs
@@ -2,10 +2,10 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use std::path::PathBuf;
 
+use crate::backend::File;
+use crate::backend::rust::RustBackend;
 use crate::backend::rust::error::GenerationError;
 use crate::backend::rust::util::codegen::ident;
-use crate::backend::rust::RustBackend;
-use crate::backend::File;
 
 impl RustBackend {
     pub fn generate_file_lib(&mut self) -> Result<File, GenerationError> {

--- a/crates/zksync-error-codegen/src/backend/rust/files/packed.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/packed.rs
@@ -1,9 +1,9 @@
 use quote::quote;
 use std::path::PathBuf;
 
-use crate::backend::rust::error::GenerationError;
-use crate::backend::rust::RustBackend;
 use crate::backend::File;
+use crate::backend::rust::RustBackend;
+use crate::backend::rust::error::GenerationError;
 
 impl RustBackend {
     pub fn generate_file_packed(&mut self) -> Result<File, GenerationError> {

--- a/crates/zksync-error-codegen/src/backend/rust/files/serialized.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/serialized.rs
@@ -1,9 +1,9 @@
 use quote::quote;
 use std::path::PathBuf;
 
-use crate::backend::rust::error::GenerationError;
-use crate::backend::rust::RustBackend;
 use crate::backend::File;
+use crate::backend::rust::RustBackend;
+use crate::backend::rust::error::GenerationError;
 
 impl RustBackend {
     pub fn generate_file_serialized(&mut self) -> Result<File, GenerationError> {

--- a/crates/zksync-error-codegen/src/backend/rust/files/untyped.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/untyped.rs
@@ -1,9 +1,9 @@
 use quote::quote;
 use std::path::PathBuf;
 
-use crate::backend::rust::error::GenerationError;
-use crate::backend::rust::RustBackend;
 use crate::backend::File;
+use crate::backend::rust::RustBackend;
+use crate::backend::rust::error::GenerationError;
 
 impl RustBackend {
     pub fn generate_file_untyped(&mut self) -> Result<File, GenerationError> {

--- a/crates/zksync-error-codegen/src/description/accessors.rs
+++ b/crates/zksync-error-codegen/src/description/accessors.rs
@@ -1,9 +1,9 @@
 use zksync_error_model::inner::{component, domain};
 
-use crate::description::error::FileFormatError;
 use crate::description::Component;
 use crate::description::Domain;
 use crate::description::Root;
+use crate::description::error::FileFormatError;
 use crate::util::LooseEq;
 
 pub fn annotate_origins(root: &mut Root, origin: &str) {

--- a/crates/zksync-error-codegen/src/description/merge/mod.rs
+++ b/crates/zksync-error-codegen/src/description/merge/mod.rs
@@ -243,7 +243,7 @@ impl Mergeable for super::FullyQualifiedType {
 mod tests {
     use maplit::btreemap;
 
-    use crate::description::merge::{error::MergeError, Mergeable as _};
+    use crate::description::merge::{Mergeable as _, error::MergeError};
 
     #[test]
     fn btreemap_merge_success() {

--- a/crates/zksync-error-codegen/src/description/merge/mod.rs
+++ b/crates/zksync-error-codegen/src/description/merge/mod.rs
@@ -104,7 +104,6 @@ impl Mergeable for Root {
         })
     }
 }
-
 impl Mergeable for Domain {
     fn merge(self, other: Self) -> Result<Self, MergeError>
     where

--- a/crates/zksync-error-codegen/src/description/normalization/mod.rs
+++ b/crates/zksync-error-codegen/src/description/normalization/mod.rs
@@ -23,7 +23,6 @@ pub fn produce_root(
     fragment: &HierarchyFragment,
     context: &BindingPoint,
 ) -> Result<Root, FileFormatError> {
-    println!("{fragment:?} and context: {context:?}");
     match (fragment, context) {
         (HierarchyFragment::Root(root), BindingPoint::Root) => Ok(root.clone()),
         (

--- a/crates/zksync-error-codegen/src/description/normalization/mod.rs
+++ b/crates/zksync-error-codegen/src/description/normalization/mod.rs
@@ -8,9 +8,9 @@ use zksync_error_model::inner::domain;
 
 use crate::description::Root;
 
-use super::error::FileFormatError;
 use super::HierarchyFragment;
 use super::HierarchyFragmentKind;
+use super::error::FileFormatError;
 
 ///
 /// Takes a hierarchy fragment and a path where it has to be merged and produces a root hierarchy ready to be merged.

--- a/crates/zksync-error-codegen/src/lib.rs
+++ b/crates/zksync-error-codegen/src/lib.rs
@@ -17,10 +17,10 @@ use loader::builder::build_model;
 use zksync_error_model::inner::Model;
 use zksync_error_model::link::Link;
 
+use crate::backend::Backend as CodegenBackend;
 use crate::backend::file::File;
 use crate::backend::mdbook::MDBookBackend;
 use crate::backend::rust::RustBackend;
-use crate::backend::Backend as CodegenBackend;
 
 pub fn default_load_and_generate(root_link: &str, input_links: Vec<&str>) {
     if let Err(e) = load_and_generate(GenerationArguments {

--- a/crates/zksync-error-codegen/src/lib.rs
+++ b/crates/zksync-error-codegen/src/lib.rs
@@ -5,15 +5,12 @@ pub mod error;
 pub mod loader;
 pub(crate) mod util;
 
-use std::io::Write as _;
-use std::path::Path;
-use std::path::PathBuf;
-
 use arguments::Backend;
 use arguments::GenerationArguments;
 use backend::IBackendConfig as _;
 use error::ProgramError;
 use loader::builder::build_model;
+use loader::resolution::overrides::Remapping;
 use zksync_error_model::inner::Model;
 use zksync_error_model::link::Link;
 
@@ -22,16 +19,16 @@ use crate::backend::file::File;
 use crate::backend::mdbook::MDBookBackend;
 use crate::backend::rust::RustBackend;
 
-pub fn default_load_and_generate(root_link: &str, input_links: Vec<&str>) {
+pub fn default_load_and_generate(input_links: Vec<&str>) {
     if let Err(e) = load_and_generate(GenerationArguments {
         verbose: true,
-        root_link: root_link.to_owned(),
         outputs: vec![arguments::BackendOutput {
             output_path: "../zksync_error".into(),
             backend: Backend::Rust,
             arguments: vec![],
         }],
         input_links: input_links.into_iter().map(Into::into).collect(),
+        override_links: vec![],
     }) {
         eprintln!("{e:#?}")
     };
@@ -57,19 +54,23 @@ where
             inner: Box::new(error),
         })
 }
+
 pub fn load_and_generate(arguments: GenerationArguments) -> Result<(), ProgramError> {
     let GenerationArguments {
         verbose,
-        root_link,
         outputs,
         input_links,
-    } = &arguments;
-    if *verbose {
-        eprintln!("Reading config from \"{root_link}\"");
-    }
+        override_links,
+    } = arguments;
 
-    let additions: Result<Vec<_>, _> = input_links.iter().map(|s| Link::parse(s)).collect();
-    let model = build_model(&Link::parse(root_link)?, &additions?, *verbose)?;
+    let model = {
+        let input_links: Vec<Link> = input_links
+            .iter()
+            .flat_map(|repr| Link::parse(repr))
+            .collect();
+        let overrides = Remapping::try_from(&override_links)?;
+        build_model(input_links, overrides, verbose)?
+    };
 
     for arguments::BackendOutput {
         output_path,
@@ -77,7 +78,7 @@ pub fn load_and_generate(arguments: GenerationArguments) -> Result<(), ProgramEr
         arguments: backend_arguments,
     } in outputs
     {
-        if *verbose {
+        if verbose {
             eprintln!("Selected backend: {backend:?}, \nGenerating files...");
         }
 
@@ -88,7 +89,7 @@ pub fn load_and_generate(arguments: GenerationArguments) -> Result<(), ProgramEr
             }
         };
 
-        if *verbose {
+        if verbose {
             eprintln!("Generation successful. Files: ");
             for file in &result {
                 eprintln!("- {}", file.relative_path.to_str().unwrap());
@@ -96,31 +97,10 @@ pub fn load_and_generate(arguments: GenerationArguments) -> Result<(), ProgramEr
             eprintln!("Writing files to disk...");
         }
 
-        create_files_in_result_directory(output_path, result)?;
-        if *verbose {
+        crate::util::io::create_files_in_result_directory(&output_path, result)?;
+        if verbose {
             eprintln!("Writing successful.");
         }
     }
-    Ok(())
-}
-
-fn create_files_in_result_directory(result_dir: &PathBuf, files: Vec<File>) -> std::io::Result<()> {
-    let result_dir = Path::new(result_dir);
-
-    if !result_dir.exists() {
-        std::fs::create_dir(result_dir)?;
-    }
-
-    for file in files {
-        let path = result_dir.join(file.relative_path);
-
-        if let Some(parent_dir) = path.parent() {
-            std::fs::create_dir_all(parent_dir)?;
-        }
-
-        let mut output_file = std::fs::File::create(&path)?;
-        output_file.write_all(file.content.as_bytes())?;
-    }
-
     Ok(())
 }

--- a/crates/zksync-error-codegen/src/loader/builder/context.rs
+++ b/crates/zksync-error-codegen/src/loader/builder/context.rs
@@ -6,9 +6,7 @@ use zksync_error_model::inner::ComponentMetadata;
 use zksync_error_model::inner::DomainMetadata;
 use zksync_error_model::link::Link;
 
-pub struct ModelTranslationContext {
-    pub origin: Link,
-}
+pub struct ModelTranslationContext;
 pub(super) struct TypeTranslationContext<'a> {
     pub type_name: &'a str,
     pub parent: &'a ModelTranslationContext,

--- a/crates/zksync-error-codegen/src/loader/builder/error.rs
+++ b/crates/zksync-error-codegen/src/loader/builder/error.rs
@@ -2,10 +2,7 @@ use zksync_error_model::error::ModelValidationError;
 use zksync_error_model::link::Link;
 use zksync_error_model::link::error::LinkError;
 
-use crate::{
-    description::merge::error::MergeError,
-    loader::error::{LoadError, TakeFromError},
-};
+use crate::{description::merge::error::MergeError, loader::error::LoadError};
 
 #[derive(Debug, thiserror::Error)]
 #[error("Missing component {component_name} in the domain {domain_name}")]
@@ -22,13 +19,6 @@ pub struct MissingDomain {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ModelBuildingError {
-    #[error("Failed to import a file {address}: {inner}")]
-    TakeFrom {
-        address: Link,
-        #[source]
-        inner: TakeFromError,
-    },
-
     #[error("Error merging description {origin}: {inner}")]
     MergeError {
         inner: Box<MergeError>,

--- a/crates/zksync-error-codegen/src/loader/builder/error.rs
+++ b/crates/zksync-error-codegen/src/loader/builder/error.rs
@@ -1,6 +1,6 @@
 use zksync_error_model::error::ModelValidationError;
-use zksync_error_model::link::error::LinkError;
 use zksync_error_model::link::Link;
+use zksync_error_model::link::error::LinkError;
 
 use crate::{
     description::merge::error::MergeError,

--- a/crates/zksync-error-codegen/src/loader/builder/mod.rs
+++ b/crates/zksync-error-codegen/src/loader/builder/mod.rs
@@ -4,6 +4,7 @@ pub mod context;
 pub mod error;
 
 use std::collections::BTreeMap;
+use std::iter;
 use std::rc::Rc;
 
 use context::ComponentTranslationContext;
@@ -35,6 +36,12 @@ use zksync_error_model::validator::validate;
 
 use crate::description::Root;
 use crate::description::merge::Mergeable as _;
+
+use super::NormalizedDescriptionFragment;
+use super::cargo::get_resolution_context;
+use super::error::LoadError;
+use super::load_fragments_multiple_sources;
+use super::resolution::overrides::Remapping;
 
 fn add_missing<U, S>(map: &mut BTreeMap<String, U>, default: U, keys: impl Iterator<Item = S>)
 where
@@ -421,51 +428,32 @@ fn bind_error_types(model: &mut Model) {
 }
 
 pub fn build_model(
-    root_link: &Link,
-    additions: &Vec<Link>,
+    sources: Vec<Link>,
+    overrides: Remapping,
     diagnostic: bool,
 ) -> Result<Model, ModelBuildingError> {
-    let root_fragment = super::load_single_fragment(root_link, &super::BindingPoint::Root)?;
+    let resolution_context = get_resolution_context(overrides);
+    let collection = load_fragments_multiple_sources(sources.into_iter(), &resolution_context)?;
 
-    let mut collection = super::load_connected_fragments(root_fragment).map_err(|inner| {
-        ModelBuildingError::TakeFrom {
-            address: root_link.clone(),
-            inner,
+    let acc = {
+        let mut acc = Root::default();
+
+        for fragment in collection {
+            acc = acc
+                .merge(fragment.root)
+                .map_err(|inner| ModelBuildingError::MergeError {
+                    inner: Box::new(inner),
+                    origin: fragment.origin,
+                })?;
         }
-    })?;
-
-    for input_link in additions {
-        let part = super::load_single_fragment(input_link, &super::BindingPoint::Root)?;
-        let connected_component = super::load_connected_fragments(part).map_err(|inner| {
-            ModelBuildingError::TakeFrom {
-                address: input_link.clone(),
-                inner,
-            }
-        })?;
-        collection.extend(connected_component);
-    }
-
-    let mut acc = Root::default();
-
-    for element in collection {
-        acc = acc
-            .merge(element.root)
-            .map_err(|inner| ModelBuildingError::MergeError {
-                inner: Box::new(inner),
-                origin: element.origin,
-            })?;
-    }
+        acc
+    };
 
     if diagnostic {
         eprintln!("\n --- Combined description ---\n{acc}")
     }
 
-    let mut root_model = translate_model(
-        &acc,
-        ModelTranslationContext {
-            origin: root_link.clone(),
-        },
-    )?;
+    let mut root_model = translate_model(&acc, ModelTranslationContext)?;
 
     add_default_error(&mut root_model);
     bind_error_types(&mut root_model);

--- a/crates/zksync-error-codegen/src/loader/builder/mod.rs
+++ b/crates/zksync-error-codegen/src/loader/builder/mod.rs
@@ -33,8 +33,8 @@ use zksync_error_model::inner::TypeMetadata;
 use zksync_error_model::inner::VersionedOwner;
 use zksync_error_model::validator::validate;
 
-use crate::description::merge::Mergeable as _;
 use crate::description::Root;
+use crate::description::merge::Mergeable as _;
 
 fn add_missing<U, S>(map: &mut BTreeMap<String, U>, default: U, keys: impl Iterator<Item = S>)
 where

--- a/crates/zksync-error-codegen/src/loader/cargo.rs
+++ b/crates/zksync-error-codegen/src/loader/cargo.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use cargo_metadata::MetadataCommand;
 use zksync_error_model::link::Link;
 
-use super::resolution::ResolutionContext;
+use super::resolution::{ResolutionContext, overrides::Remapping};
 
 const METADATA_CATEGORY: &str = "zksync_error_codegen";
 
@@ -13,12 +13,15 @@ pub struct CollectionFile {
     pub absolute_path: PathBuf,
 }
 
-pub fn get_resolution_context() -> ResolutionContext {
+pub fn get_resolution_context(overrides: Remapping) -> ResolutionContext {
     let metadata = MetadataCommand::new()
         .exec()
         .expect("Failed to fetch cargo metadata");
 
-    let mut context = ResolutionContext::default();
+    let mut context = ResolutionContext {
+        files: vec![],
+        overrides,
+    };
 
     for pkg in &metadata.packages {
         if let Some(codegen_meta) = pkg.metadata.get(METADATA_CATEGORY) {

--- a/crates/zksync-error-codegen/src/loader/error.rs
+++ b/crates/zksync-error-codegen/src/loader/error.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use super::builder::error::ModelBuildingError;
 use super::resolution::error::ResolutionError;
 use crate::description::error::FileFormatError;
-use zksync_error_model::link::error::LinkError;
 use zksync_error_model::link::Link;
+use zksync_error_model::link::error::LinkError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum TakeFromError {
@@ -14,7 +14,9 @@ pub enum TakeFromError {
     #[error("Error while building model following a `take_from` link: {0}")]
     LinkError(#[from] LinkError),
 
-    #[error("Circular dependency detected: file {trigger} attempted to reference {visited} which was already visited.")]
+    #[error(
+        "Circular dependency detected: file {trigger} attempted to reference {visited} which was already visited."
+    )]
     CircularDependency { trigger: Link, visited: Link },
 }
 

--- a/crates/zksync-error-codegen/src/loader/fetch.rs
+++ b/crates/zksync-error-codegen/src/loader/fetch.rs
@@ -7,7 +7,7 @@ use zksync_error_model::link::Link;
 
 use crate::loader::cargo::get_resolution_context;
 use crate::loader::error::LoadError;
-use crate::loader::resolution::{resolve, ResolvedLink};
+use crate::loader::resolution::{ResolvedLink, resolve};
 
 fn from_fs(path: &PathBuf) -> Result<String, LoadError> {
     eprintln!(

--- a/crates/zksync-error-codegen/src/loader/fetch.rs
+++ b/crates/zksync-error-codegen/src/loader/fetch.rs
@@ -5,9 +5,10 @@ use reqwest;
 
 use zksync_error_model::link::Link;
 
-use crate::loader::cargo::get_resolution_context;
 use crate::loader::error::LoadError;
 use crate::loader::resolution::{ResolvedLink, resolve};
+
+use super::resolution::ResolutionContext;
 
 fn from_fs(path: &PathBuf) -> Result<String, LoadError> {
     eprintln!(
@@ -27,9 +28,8 @@ fn from_network(url: &str) -> Result<String, reqwest::Error> {
     Ok(content)
 }
 
-pub fn load_text(link: &Link) -> Result<String, LoadError> {
-    let context = get_resolution_context();
-    Ok(match resolve(link, &context)? {
+pub fn load_text(link: &Link, context: &ResolutionContext) -> Result<String, LoadError> {
+    Ok(match resolve(link, context)? {
         ResolvedLink::DescriptionFile(description_file) => {
             from_fs(&description_file.absolute_path)?
         }

--- a/crates/zksync-error-codegen/src/loader/mod.rs
+++ b/crates/zksync-error-codegen/src/loader/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use error::LoadError;
+use fetch::LoadResult;
 use fetch::load_text;
 use resolution::ResolutionContext;
 use zksync_error_model::link::Link;
@@ -39,10 +40,10 @@ fn load_single_fragment(
     context: &ResolutionContext,
 ) -> Result<NormalizedDescriptionFragment, LoadError> {
     let origin = link.clone();
-    let contents = load_text(link, context)?;
-    match root_from_text(&contents, binding) {
+    let LoadResult { text, actual } = load_text(link, context)?;
+    match root_from_text(&text, binding) {
         Ok(mut root) => {
-            annotate_origins(&mut root, &origin.to_string());
+            annotate_origins(&mut root, &actual.to_string());
             Ok(NormalizedDescriptionFragment { origin, root })
         }
         Err(inner) => Err(LoadError::FileFormatError { origin, inner }),

--- a/crates/zksync-error-codegen/src/loader/mod.rs
+++ b/crates/zksync-error-codegen/src/loader/mod.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeSet;
 
 use error::LoadError;
-use error::TakeFromError;
 use fetch::load_text;
+use resolution::ResolutionContext;
 use zksync_error_model::link::Link;
 
 use crate::description::HierarchyFragment;
@@ -36,13 +36,13 @@ fn root_from_text(contents: &str, context: &BindingPoint) -> Result<Root, FileFo
 fn load_single_fragment(
     link: &Link,
     binding: &BindingPoint,
+    context: &ResolutionContext,
 ) -> Result<NormalizedDescriptionFragment, LoadError> {
     let origin = link.clone();
-    let contents = load_text(link)?;
+    let contents = load_text(link, context)?;
     match root_from_text(&contents, binding) {
         Ok(mut root) => {
             annotate_origins(&mut root, &origin.to_string());
-
             Ok(NormalizedDescriptionFragment { origin, root })
         }
         Err(inner) => Err(LoadError::FileFormatError { origin, inner }),
@@ -52,14 +52,15 @@ fn load_single_fragment(
 fn fetch_connected_fragments_aux(
     fragment: NormalizedDescriptionFragment,
     visited: &mut BTreeSet<Link>,
-) -> Result<Vec<NormalizedDescriptionFragment>, TakeFromError> {
+    context: &ResolutionContext,
+) -> Result<Vec<NormalizedDescriptionFragment>, LoadError> {
     let mut results = vec![];
     let NormalizedDescriptionFragment { origin, root } = &fragment;
 
     let visit =
-        |link, binding: &BindingPoint, visited: &mut BTreeSet<Link>| -> Result<_, TakeFromError> {
-            let new_fragment = load_single_fragment(&link, binding)?;
-            let addend = fetch_connected_fragments_aux(new_fragment, visited)?;
+        |link, binding: &BindingPoint, visited: &mut BTreeSet<Link>| -> Result<_, LoadError> {
+            let new_fragment = load_single_fragment(&link, binding, context)?;
+            let addend = fetch_connected_fragments_aux(new_fragment, visited, context)?;
             visited.insert(link.clone());
             Ok(addend)
         };
@@ -72,7 +73,7 @@ fn fetch_connected_fragments_aux(
         for raw_link in &domain.take_from {
             let link = Link::parse(raw_link)?;
             if visited.contains(&link) {
-                return Err(TakeFromError::CircularDependency {
+                return Err(LoadError::CircularDependency {
                     trigger: origin.clone(),
                     visited: link.clone(),
                 });
@@ -86,7 +87,7 @@ fn fetch_connected_fragments_aux(
             for raw_link in &component.take_from {
                 let link = Link::parse(raw_link)?;
                 if visited.contains(&link) {
-                    return Err(TakeFromError::CircularDependency {
+                    return Err(LoadError::CircularDependency {
                         trigger: origin.clone(),
                         visited: link.clone(),
                     });
@@ -102,14 +103,32 @@ fn fetch_connected_fragments_aux(
 
 pub fn load_connected_fragments(
     fragment: NormalizedDescriptionFragment,
-) -> Result<Vec<NormalizedDescriptionFragment>, TakeFromError> {
-    let result = fetch_connected_fragments_aux(fragment, &mut BTreeSet::new())?;
+    context: &ResolutionContext,
+) -> Result<Vec<NormalizedDescriptionFragment>, LoadError> {
+    let result = fetch_connected_fragments_aux(fragment, &mut BTreeSet::new(), context)?;
     Ok(result)
 }
 
-pub fn load_fragments(link: Link) -> Result<Vec<NormalizedDescriptionFragment>, TakeFromError> {
-    let root_fragment = load_single_fragment(&link, &BindingPoint::Root)?;
-    load_connected_fragments(root_fragment)
+pub fn load_fragments(
+    link: Link,
+    context: &ResolutionContext,
+) -> Result<Vec<NormalizedDescriptionFragment>, LoadError> {
+    let root_fragment = load_single_fragment(&link, &BindingPoint::Root, context)?;
+    load_connected_fragments(root_fragment, context).map_err(|inner| LoadError::TakeFrom {
+        address: link.clone(),
+        inner: Box::new(inner),
+    })
+}
+
+pub fn load_fragments_multiple_sources(
+    links: impl Iterator<Item = Link>,
+    context: &ResolutionContext,
+) -> Result<Vec<NormalizedDescriptionFragment>, LoadError> {
+    let mut collection = vec![];
+    for fragment in links.map(|link| load_fragments(link, context)) {
+        collection.extend(fragment?);
+    }
+    Ok(collection)
 }
 
 pub(crate) static ZKSYNC_ROOT_CONTENTS: &str = include_str!(concat!(

--- a/crates/zksync-error-codegen/src/loader/mod.rs
+++ b/crates/zksync-error-codegen/src/loader/mod.rs
@@ -5,12 +5,12 @@ use error::TakeFromError;
 use fetch::load_text;
 use zksync_error_model::link::Link;
 
+use crate::description::HierarchyFragment;
+use crate::description::Root;
 use crate::description::accessors::annotate_origins;
 use crate::description::error::FileFormatError;
 use crate::description::normalization::binding::BindingPoint;
 use crate::description::normalization::produce_root;
-use crate::description::HierarchyFragment;
-use crate::description::Root;
 
 pub mod builder;
 pub mod cargo;

--- a/crates/zksync-error-codegen/src/loader/resolution/error.rs
+++ b/crates/zksync-error-codegen/src/loader/resolution/error.rs
@@ -10,5 +10,8 @@ pub enum ResolutionError {
         context: ResolutionContext,
     },
     #[error("Failed to resolve `{link}`.")]
-    GenericLinkResolutionError { link: Link },
+    GenericLinkResolutionError {
+        link: Link,
+        context: ResolutionContext,
+    },
 }

--- a/crates/zksync-error-codegen/src/loader/resolution/mod.rs
+++ b/crates/zksync-error-codegen/src/loader/resolution/mod.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use error::ResolutionError;
 use zksync_error_model::link::Link;
 
-use super::cargo::{link_matches, CollectionFile};
+use super::cargo::{CollectionFile, link_matches};
 
 #[derive(Clone, Debug, Default)]
 pub struct ResolutionContext {

--- a/crates/zksync-error-codegen/src/loader/resolution/mod.rs
+++ b/crates/zksync-error-codegen/src/loader/resolution/mod.rs
@@ -21,6 +21,10 @@ impl ResolutionContext {
     }
 }
 
+pub struct ResolutionResult {
+    pub actual: Link,
+    pub resolved: ResolvedLink,
+}
 pub enum ResolvedLink {
     DescriptionFile(CollectionFile),
     LocalPath(PathBuf),
@@ -31,29 +35,35 @@ pub enum ResolvedLink {
 pub fn resolve(
     query_link: &Link,
     context: &ResolutionContext,
-) -> Result<ResolvedLink, ResolutionError> {
+) -> Result<ResolutionResult, ResolutionError> {
     match context.overrides.map.get(query_link).cloned() {
         Some(overridden) => {
             //TODO: eventually a stack to keep track of the path
             eprintln!("Overriding {query_link} with {overridden}...");
             resolve(&overridden, context)
         }
-        None => match query_link {
-            link @ Link::PackageLink { .. } => {
-                if let Some(df) = context.files.iter().find(|file| link_matches(link, file)) {
-                    Ok(ResolvedLink::DescriptionFile(df.clone()))
-                } else {
-                    Err(ResolutionError::CargoLinkResolutionError {
-                        link: link.clone(),
-                        context: context.clone(),
-                    })
+        None => {
+            let resolved = match query_link {
+                link @ Link::PackageLink { .. } => {
+                    if let Some(df) = context.files.iter().find(|file| link_matches(link, file)) {
+                        Ok(ResolvedLink::DescriptionFile(df.clone()))
+                    } else {
+                        Err(ResolutionError::CargoLinkResolutionError {
+                            link: link.clone(),
+                            context: context.clone(),
+                        })
+                    }
                 }
-            }
-            Link::FileLink { path } => Ok(ResolvedLink::LocalPath(path.into())),
-            Link::URL { url } => Ok(ResolvedLink::Url(url.to_owned())),
-            Link::DefaultLink => Ok(ResolvedLink::Immediate(
-                super::ZKSYNC_ROOT_CONTENTS.to_owned(),
-            )),
-        },
+                Link::FileLink { path } => Ok(ResolvedLink::LocalPath(path.into())),
+                Link::URL { url } => Ok(ResolvedLink::Url(url.to_owned())),
+                Link::DefaultLink => Ok(ResolvedLink::Immediate(
+                    super::ZKSYNC_ROOT_CONTENTS.to_owned(),
+                )),
+            }?;
+            Ok(ResolutionResult {
+                actual: query_link.clone(),
+                resolved,
+            })
+        }
     }
 }

--- a/crates/zksync-error-codegen/src/loader/resolution/overrides.rs
+++ b/crates/zksync-error-codegen/src/loader/resolution/overrides.rs
@@ -1,0 +1,22 @@
+use std::collections::BTreeMap;
+
+use zksync_error_model::link::{Link, error::LinkError};
+
+#[derive(Clone, Debug)]
+pub struct Remapping {
+    pub map: BTreeMap<Link, Link>,
+}
+
+impl TryFrom<&Vec<(String, String)>> for Remapping {
+    type Error = LinkError;
+
+    fn try_from(value: &Vec<(String, String)>) -> Result<Self, Self::Error> {
+        let mut map: BTreeMap<Link, Link> = Default::default();
+
+        for (fst, snd) in value {
+            map.insert(Link::parse(fst)?, Link::parse(snd)?);
+        }
+
+        Ok(Remapping { map })
+    }
+}

--- a/crates/zksync-error-codegen/src/util/io.rs
+++ b/crates/zksync-error-codegen/src/util/io.rs
@@ -1,0 +1,30 @@
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use crate::backend::file::File;
+
+pub(crate) fn create_files_in_result_directory(
+    result_dir: &PathBuf,
+    files: Vec<File>,
+) -> std::io::Result<()> {
+    let result_dir = Path::new(result_dir);
+
+    if !result_dir.exists() {
+        std::fs::create_dir(result_dir)?;
+    }
+
+    for file in files {
+        let path = result_dir.join(file.relative_path);
+
+        if let Some(parent_dir) = path.parent() {
+            std::fs::create_dir_all(parent_dir)?;
+        }
+
+        let mut output_file = std::fs::File::create(&path)?;
+        output_file.write_all(file.content.as_bytes())?;
+    }
+
+    Ok(())
+}

--- a/crates/zksync-error-codegen/src/util/mod.rs
+++ b/crates/zksync-error-codegen/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub mod io;
 pub mod printing;
 
 pub trait LooseEq<I> {

--- a/crates/zksync-error-model/Cargo.toml
+++ b/crates/zksync-error-model/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 
 [dependencies]
 
+const_format.workspace = true
 derive_more.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/zksync-error-model/src/error.rs
+++ b/crates/zksync-error-model/src/error.rs
@@ -4,7 +4,9 @@ use crate::inner::{ComponentMetadata, DomainMetadata, ErrorDescription};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ModelValidationError {
-    #[error("Unknown model type {0}. Ensure the \"types\" object of the error definitions file contains it.")]
+    #[error(
+        "Unknown model type {0}. Ensure the \"types\" object of the error definitions file contains it."
+    )]
     UnknownType(String),
     #[error("Type {0} has no mappings for the Rust backend.")]
     UnmappedType(String),

--- a/crates/zksync-error-model/src/link/mod.rs
+++ b/crates/zksync-error-model/src/link/mod.rs
@@ -61,7 +61,9 @@ impl std::fmt::Display for Link {
             )),
             Link::URL { url } => f.write_str(url),
             Link::FileLink { path } => f.write_str(path),
-            Link::DefaultLink => f.write_fmt(format_args!("<default {}>", Self::DEFAULT_ROOT_FILE_NAME)),
+            Link::DefaultLink => {
+                f.write_fmt(format_args!("<default {}>", Self::DEFAULT_ROOT_FILE_NAME))
+            }
         }
     }
 }

--- a/crates/zksync-error-model/src/link/mod.rs
+++ b/crates/zksync-error-model/src/link/mod.rs
@@ -1,3 +1,5 @@
+use const_format::concatcp;
+
 use error::LinkError;
 
 pub mod error;
@@ -15,6 +17,9 @@ impl Link {
     pub const CARGO_FORMAT_PREFIX: &str = "cargo";
     pub const FILE_FORMAT_PREFIX: &str = "file";
     pub const DEFAULT_FORMAT_PREFIX: &str = "zksync-error";
+    pub const DEFAULT_ROOT_FILE_NAME_NO_EXTENSION: &str = "zksync-root";
+    pub const DEFAULT_ROOT_FILE_NAME: &str =
+        concatcp!(Link::DEFAULT_ROOT_FILE_NAME_NO_EXTENSION, ".json");
     pub const NETWORK_FORMAT_PREFIXES: [&str; 2] = ["https", "http"];
     pub const PACKAGE_SEPARATOR: &str = "@@";
 
@@ -34,7 +39,9 @@ impl Link {
             Some((Link::FILE_FORMAT_PREFIX, path)) => Ok(Link::FileLink {
                 path: path.to_owned(),
             }),
-            Some((Link::DEFAULT_FORMAT_PREFIX, "zksync-root.json")) => Ok(Link::DefaultLink),
+            Some((Link::DEFAULT_FORMAT_PREFIX, Self::DEFAULT_ROOT_FILE_NAME)) => {
+                Ok(Link::DefaultLink)
+            }
             Some((prefix, _)) if Link::NETWORK_FORMAT_PREFIXES.contains(&prefix) => {
                 Ok(Link::URL { url: string })
             }
@@ -54,7 +61,7 @@ impl std::fmt::Display for Link {
             )),
             Link::URL { url } => f.write_str(url),
             Link::FileLink { path } => f.write_str(path),
-            Link::DefaultLink => f.write_str("<default zksync-root.json>"),
+            Link::DefaultLink => f.write_fmt(format_args!("<default {}>", Self::DEFAULT_ROOT_FILE_NAME)),
         }
     }
 }

--- a/docs/src/description/07-links.md
+++ b/docs/src/description/07-links.md
@@ -22,18 +22,18 @@ There are three types of links:
 
 ## Usage
 
-1. The construction of hierarchy starts with the root JSON file; you should
-   provide a link to it:
-
-    - when using CLI -- through option `--root-definitions` 
-    - when using `zksync-error-codegen` as a library -- through the field `root_link` of the structure `zksync_error_codegen::arguments::GenerationArguments`:
+1. Links identify the starting JSON files:
+    - when using CLI -- through option `--source` 
+    - when using `zksync-error-codegen` as a library -- through the field
+      `input_links` of the structure
+      `zksync_error_codegen::arguments::GenerationArguments`:
 
     ```rust
-    pub struct GenerationArguments {
-        pub verbose: bool,
-        pub root_link: String,
-        pub input_links: Vec<String>,
-        pub outputs: Vec<BackendOutput>,
+pub struct GenerationArguments {
+    pub verbose: bool,
+    pub input_links: Vec<String>,
+    pub override_links: Vec<(String, String)>,
+    pub outputs: Vec<BackendOutput>,
     }
     ```
 
@@ -53,3 +53,4 @@ There are three types of links:
   In this case files are fetched, their contents are parsed, filtered and merged
   into the root model. The filtering selects only the domain/component with the
   same values of fields `name`, `code`, and `identifier_encoding`.
+  Instead of URLs you may, of course, use any type of links.

--- a/zksync-root.json
+++ b/zksync-root.json
@@ -236,6 +236,9 @@
             "bindings": {
                 "rust": "AnvilZksync"
             },
+            "take_from" : [
+                "https://raw.githubusercontent.com/matter-labs/anvil-zksync/refs/heads/main/etc/errors/anvil.json"
+            ],
             "components" : []
         },
         {


### PR DESCRIPTION
Implement overrides on the link level.

Now we may pass JSON with a link remapping and the remapping will be applied at link resolution time.

```
cargo run -- \
 --source zksync-error://zksync-root.json \
--backend rust \
-a generate_cargo_toml=false \
-a use_anyhow=true \
--verbose \
--output test-output \
--remap '{"https://raw.githubusercontent.com/matter-labs/anvil-zksync/refs/heads/main/etc/errors/anvil.json":"t.json"}'
```