### PR TITLE
feat: support wrapping domain-level errors

### DIFF
--- a/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
@@ -191,6 +191,7 @@ impl RustBackend {
             use strum_macros::AsRefStr;
             use strum_macros::EnumDiscriminants;
             use strum_macros::FromRepr;
+            use crate::error::domains::*;
 
             #( #definitions )*
         };


### PR DESCRIPTION
Previously only subdomain errors could have been wrapped.
This also fixes a future typescript backend bug