### PR TITLE
feat: support github links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,6 +2496,8 @@ dependencies = [
 name = "zksync-error-codegen"
 version = "0.1.0"
 dependencies = [
+ "const_format",
+ "derive_more",
  "include_dir",
  "maplit",
  "proc-macro2",
@@ -2536,7 +2538,6 @@ dependencies = [
 name = "zksync-error-model"
 version = "0.1.0"
 dependencies = [
- "const_format",
  "derive_more",
  "serde",
  "thiserror 2.0.12",

--- a/crates/zksync-error-codegen/Cargo.toml
+++ b/crates/zksync-error-codegen/Cargo.toml
@@ -12,6 +12,8 @@ edition.workspace = true
 # External dependencies #
 #########################
 
+const_format.workspace = true
+derive_more.workspace = true
 include_dir.workspace = true
 maplit.workspace = true
 proc-macro2.workspace = true

--- a/crates/zksync-error-codegen/src/description/mod.rs
+++ b/crates/zksync-error-codegen/src/description/mod.rs
@@ -8,6 +8,7 @@ pub mod display;
 pub mod error;
 pub mod merge;
 pub mod normalization;
+pub mod parsers;
 
 use std::collections::BTreeMap;
 
@@ -15,6 +16,7 @@ use error::FileFormatError;
 use serde::Deserialize;
 use serde::Serialize;
 use strum_macros::EnumDiscriminants;
+use zksync_error_model::link::github::GithubLink;
 
 pub type Origins = Vec<String>;
 pub type TypeMappings = BTreeMap<String, FullyQualifiedType>;
@@ -27,7 +29,7 @@ pub struct Root {
     #[serde(default)]
     pub domains: Vec<Domain>,
     #[serde(default)]
-    pub take_from: Vec<String>,
+    pub take_from: Vec<TakeFromLink>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -47,6 +49,12 @@ pub struct FullyQualifiedType {
     pub expression: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TakeFromLink {
+    GithubLink(GithubLink),
+    OrdinaryLink(String),
+}
 #[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct Domain {
     pub domain_name: String,
@@ -61,7 +69,7 @@ pub struct Domain {
     #[serde(default)]
     pub bindings: BTreeMap<String, String>,
     #[serde(default)]
-    pub take_from: Vec<String>,
+    pub take_from: Vec<TakeFromLink>,
     #[serde(skip_deserializing)]
     pub origins: Origins,
 }
@@ -80,7 +88,7 @@ pub struct Component {
     #[serde(default)]
     pub bindings: BTreeMap<String, String>,
     #[serde(default)]
-    pub take_from: Vec<String>,
+    pub take_from: Vec<TakeFromLink>,
 
     #[serde(default)]
     pub errors: Vec<Error>,

--- a/crates/zksync-error-codegen/src/description/parsers/link.rs
+++ b/crates/zksync-error-codegen/src/description/parsers/link.rs
@@ -1,0 +1,205 @@
+use crate::description::TakeFromLink;
+use const_format::concatcp;
+use zksync_error_model::link::Link;
+
+#[derive(Debug, derive_more::Display, thiserror::Error)]
+pub enum LinkError {
+    #[display("Link `{_0}` has an invalid format.")]
+    InvalidLinkFormat(String),
+}
+
+/// The protocol prefix used to explicitly denote file links.
+/// Example: "file://path/to/resource"
+pub const FILE_FORMAT_PREFIX: &str = "file";
+
+/// The base directory path for zksync descriptions.
+pub const ZKSYNC_DESCRIPTIONS_LOCATION: &str = "descriptions/";
+
+/// The protocol prefix used for embedded/bundled resources.
+/// Example: "zksync-error://resource/path"
+pub const EMBEDDED_FORMAT_PREFIX: &str = "zksync-error";
+
+/// The default filename (without extension) for the root description file.
+pub const DEFAULT_ROOT_FILE_NAME_NO_EXTENSION: &str = "zksync-root";
+
+/// The complete default path to the root description file.
+/// Combines the descriptions location with the default root filename and JSON extension.
+pub const DEFAULT_ROOT_FILE_PATH: &str = concatcp!(
+    ZKSYNC_DESCRIPTIONS_LOCATION,
+    DEFAULT_ROOT_FILE_NAME_NO_EXTENSION,
+    ".json"
+);
+
+/// Array of protocol prefixes that indicate network-based URLs.
+pub const NETWORK_FORMAT_PREFIXES: [&str; 2] = ["https", "http"];
+
+/// Separator used in package identifiers.
+pub const PACKAGE_SEPARATOR: &str = "@@";
+
+pub fn parse(link: &TakeFromLink) -> Result<Link, LinkError> {
+    match link {
+        TakeFromLink::GithubLink(github_link) => Ok(Link::Github(github_link.clone())),
+        TakeFromLink::OrdinaryLink(string) => match string.split_once("://") {
+            Some((FILE_FORMAT_PREFIX, path)) => Ok(Link::FileLink {
+                path: path.to_owned(),
+            }),
+            Some((EMBEDDED_FORMAT_PREFIX, path)) => Ok(Link::Bundled {
+                path: path.to_owned(),
+            }),
+            Some((prefix, _)) if NETWORK_FORMAT_PREFIXES.contains(&prefix) => Ok(Link::URL {
+                url: string.to_owned(),
+            }),
+            None => Ok(Link::FileLink {
+                path: string.to_owned(),
+            }),
+            Some(_) => Err(LinkError::InvalidLinkFormat(string.to_owned())),
+        },
+    }
+}
+
+pub fn parse_str(link: &str) -> Result<Link, LinkError> {
+    let take_from_link = serde_json::from_str::<TakeFromLink>(link)
+        .or(serde_json::from_str::<TakeFromLink>(&format!("\"{link}\"")))
+        .map_err(|_| LinkError::InvalidLinkFormat(link.to_owned()))?;
+    parse(&take_from_link)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zksync_error_model::link::{
+        Link,
+        github::{BranchName, CommitHash, GithubLink, ReferenceType},
+    };
+
+    fn sample_github_link_branch() -> GithubLink {
+        GithubLink::new_with_branch(
+            "zk/repo".to_string(),
+            "path/to/file".to_string(),
+            BranchName("dev".to_string()),
+        )
+    }
+
+    fn sample_github_link_commit() -> GithubLink {
+        GithubLink::new_with_commit(
+            "zk/repo".to_string(),
+            "path/to/file".to_string(),
+            CommitHash("deadbeef".to_string()),
+        )
+    }
+
+    #[test]
+    fn test_parse_github_link_branch() {
+        let link = TakeFromLink::GithubLink(sample_github_link_branch());
+        let parsed = parse(&link).unwrap();
+        match parsed {
+            Link::Github(gl) => assert_eq!(gl.repo, "zk/repo"),
+            _ => panic!("Expected Github link"),
+        }
+    }
+
+    #[test]
+    fn test_parse_github_link_commit() {
+        let link = TakeFromLink::GithubLink(sample_github_link_commit());
+        let parsed = parse(&link).unwrap();
+        match parsed {
+            Link::Github(gl) => {
+                assert_eq!(gl.repo, "zk/repo");
+                assert!(matches!(gl.reference, ReferenceType::Commit { .. }));
+            }
+            _ => panic!("Expected Github link"),
+        }
+    }
+
+    #[test]
+    fn test_parse_file_link() {
+        let link = TakeFromLink::OrdinaryLink("file://path/to/file.json".to_string());
+        let parsed = parse(&link).unwrap();
+        assert_eq!(
+            parsed,
+            Link::FileLink {
+                path: "path/to/file.json".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_embedded_link() {
+        let link = TakeFromLink::OrdinaryLink("zksync-error://resource/path".to_string());
+        let parsed = parse(&link).unwrap();
+        assert_eq!(
+            parsed,
+            Link::Bundled {
+                path: "resource/path".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_http_link() {
+        let url = "http://example.com/resource.json";
+        let link = TakeFromLink::OrdinaryLink(url.to_string());
+        let parsed = parse(&link).unwrap();
+        assert_eq!(
+            parsed,
+            Link::URL {
+                url: url.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_https_link() {
+        let url = "https://example.com/resource.json";
+        let link = TakeFromLink::OrdinaryLink(url.to_string());
+        let parsed = parse(&link).unwrap();
+        assert_eq!(
+            parsed,
+            Link::URL {
+                url: url.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_bare_file_path() {
+        let path = "local/path.json";
+        let link = TakeFromLink::OrdinaryLink(path.to_string());
+        let parsed = parse(&link).unwrap();
+        assert_eq!(
+            parsed,
+            Link::FileLink {
+                path: path.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_prefix() {
+        let link = TakeFromLink::OrdinaryLink("invalidprefix://data".to_string());
+        let result = parse(&link);
+        assert!(matches!(result, Err(LinkError::InvalidLinkFormat(_))));
+    }
+
+    #[test]
+    fn test_parse_str_valid_github() {
+        let json = serde_json::json!({
+            "repo": "zk/repo",
+            "path": "test/path",
+            "branch": "main"
+        });
+        let json_str = json.to_string();
+        let parsed = parse_str(&json_str).unwrap();
+        match parsed {
+            Link::Github(gl) => assert_eq!(gl.repo, "zk/repo"),
+            _ => panic!("Expected Github link"),
+        }
+    }
+
+    #[test]
+    fn test_parse_str_invalid_json() {
+        let invalid_json = "{not a valid json}";
+        let result = parse_str(invalid_json);
+        assert!(matches!(result, Ok(Link::FileLink { .. })));
+    }
+}

--- a/crates/zksync-error-codegen/src/description/parsers/mod.rs
+++ b/crates/zksync-error-codegen/src/description/parsers/mod.rs
@@ -1,0 +1,1 @@
+pub mod link;

--- a/crates/zksync-error-codegen/src/error.rs
+++ b/crates/zksync-error-codegen/src/error.rs
@@ -1,7 +1,7 @@
+use crate::description::parsers::link::LinkError;
 use crate::loader::builder::error::ModelBuildingError;
 use crate::loader::error::LoadError;
 use zksync_error_model::error::ModelValidationError;
-use zksync_error_model::link::error::LinkError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProgramError {

--- a/crates/zksync-error-codegen/src/lib.rs
+++ b/crates/zksync-error-codegen/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod util;
 use arguments::Backend;
 use arguments::GenerationArguments;
 use backend::IBackendConfig as _;
+use description::parsers::link;
 use error::ProgramError;
 use loader::builder::build_model;
 use loader::resolution::overrides::Remapping;
@@ -64,8 +65,10 @@ pub fn load_and_generate(arguments: GenerationArguments) -> Result<(), ProgramEr
     } = arguments;
 
     let model = {
-        let input_links: Result<Vec<Link>, _> =
-            input_links.iter().map(|repr| Link::parse(repr)).collect();
+        let input_links: Result<Vec<Link>, _> = input_links
+            .iter()
+            .map(|repr| link::parse_str(repr))
+            .collect();
         let overrides = Remapping::try_from(&override_links)?;
         build_model(input_links?, overrides, verbose)?
     };

--- a/crates/zksync-error-codegen/src/loader/builder/error.rs
+++ b/crates/zksync-error-codegen/src/loader/builder/error.rs
@@ -1,6 +1,5 @@
 use zksync_error_model::error::ModelValidationError;
 use zksync_error_model::link::Link;
-use zksync_error_model::link::error::LinkError;
 
 use crate::{description::merge::error::MergeError, loader::error::LoadError};
 

--- a/crates/zksync-error-codegen/src/loader/error.rs
+++ b/crates/zksync-error-codegen/src/loader/error.rs
@@ -1,9 +1,8 @@
 use std::path::PathBuf;
 
 use super::resolution::error::ResolutionError;
-use crate::description::error::FileFormatError;
+use crate::description::{error::FileFormatError, parsers::link::LinkError};
 use zksync_error_model::link::Link;
-use zksync_error_model::link::error::LinkError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum LoadError {

--- a/crates/zksync-error-codegen/src/loader/fetch.rs
+++ b/crates/zksync-error-codegen/src/loader/fetch.rs
@@ -33,7 +33,7 @@ fn from_embedded(path: &Path) -> Result<String, LoadError> {
         .get_file(path)
         .map(|f| f.path())
     {
-        from_fs(&path.to_owned())
+        from_fs(path)
     } else {
         fs::read_to_string(path).map_err(|inner| LoadError::IOError {
             path: path.into(),

--- a/crates/zksync-error-codegen/src/loader/mod.rs
+++ b/crates/zksync-error-codegen/src/loader/mod.rs
@@ -13,6 +13,7 @@ use crate::description::accessors::annotate_origins;
 use crate::description::error::FileFormatError;
 use crate::description::normalization::binding::BindingPoint;
 use crate::description::normalization::produce_root;
+use crate::description::parsers::link;
 
 pub mod builder;
 pub mod error;
@@ -84,7 +85,7 @@ fn fetch_connected_fragments_aux(
     visited.insert(origin.clone());
 
     for raw_link in &fragment.root.take_from {
-        let link = Link::parse(raw_link)?;
+        let link = link::parse(raw_link)?;
         if visited.contains(&link) {
             return Err(LoadError::CircularDependency {
                 trigger: origin.clone(),
@@ -99,7 +100,7 @@ fn fetch_connected_fragments_aux(
         let domain_binding = BindingPoint::for_domain(domain);
 
         for raw_link in &domain.take_from {
-            let link = Link::parse(raw_link)?;
+            let link = link::parse(raw_link)?;
             if visited.contains(&link) {
                 return Err(LoadError::CircularDependency {
                     trigger: origin.clone(),
@@ -113,7 +114,7 @@ fn fetch_connected_fragments_aux(
             let component_binding = BindingPoint::for_component(domain, component);
 
             for raw_link in &component.take_from {
-                let link = Link::parse(raw_link)?;
+                let link = link::parse(raw_link)?;
                 if visited.contains(&link) {
                     return Err(LoadError::CircularDependency {
                         trigger: origin.clone(),

--- a/crates/zksync-error-codegen/src/loader/resolution/mod.rs
+++ b/crates/zksync-error-codegen/src/loader/resolution/mod.rs
@@ -44,6 +44,7 @@ pub fn resolve(
                     )
                     .into(),
                 )),
+                Link::Github(github_link) => Ok(ResolvedLink::Url(github_link.to_url())),
             }?;
             Ok(ResolutionResult {
                 actual: query_link.clone(),

--- a/crates/zksync-error-codegen/src/loader/resolution/overrides.rs
+++ b/crates/zksync-error-codegen/src/loader/resolution/overrides.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 
-use zksync_error_model::link::{Link, error::LinkError};
+use zksync_error_model::link::Link;
+
+use crate::description::parsers::link::{self, LinkError};
 
 #[derive(Clone, Debug)]
 pub struct Remapping {
@@ -14,7 +16,7 @@ impl TryFrom<&Vec<(String, String)>> for Remapping {
         let mut map: BTreeMap<Link, Link> = Default::default();
 
         for (fst, snd) in value {
-            map.insert(Link::parse(fst)?, Link::parse(snd)?);
+            map.insert(link::parse_str(fst)?, link::parse_str(snd)?);
         }
 
         Ok(Remapping { map })

--- a/crates/zksync-error-model/Cargo.toml
+++ b/crates/zksync-error-model/Cargo.toml
@@ -8,7 +8,6 @@ version.workspace = true
 
 [dependencies]
 
-const_format.workspace = true
 derive_more.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/zksync-error-model/src/link/error.rs
+++ b/crates/zksync-error-model/src/link/error.rs
@@ -1,5 +1,0 @@
-#[derive(Debug, derive_more::Display, thiserror::Error)]
-pub enum LinkError {
-    #[display("Link `{_0}` has an invalid format.")]
-    InvalidLinkFormat(String),
-}

--- a/crates/zksync-error-model/src/link/github.rs
+++ b/crates/zksync-error-model/src/link/github.rs
@@ -1,0 +1,98 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BranchName(pub String);
+
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+pub struct CommitHash(pub String);
+
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+pub struct GithubLink {
+    pub repo: String,
+    pub path: String,
+    #[serde(flatten)]
+    pub reference: ReferenceType,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+#[serde(untagged)]
+pub enum ReferenceType {
+    Branch {
+        #[serde(default = "default_branch")]
+        branch: BranchName,
+    },
+    Commit {
+        commit: CommitHash,
+    },
+}
+
+impl Default for ReferenceType {
+    fn default() -> Self {
+        ReferenceType::Branch {
+            branch: default_branch(),
+        }
+    }
+}
+
+fn default_branch() -> BranchName {
+    BranchName("main".to_string())
+}
+
+impl GithubLink {
+    pub fn new_with_branch(repo: String, path: String, branch: BranchName) -> Self {
+        Self {
+            repo,
+            path,
+            reference: ReferenceType::Branch { branch },
+        }
+    }
+
+    pub fn new_with_commit(repo: String, path: String, commit: CommitHash) -> Self {
+        Self {
+            repo,
+            path,
+            reference: ReferenceType::Commit { commit },
+        }
+    }
+
+    pub fn to_url(&self) -> String {
+        let Self {
+            repo,
+            path,
+            reference,
+        } = self;
+        match reference {
+            ReferenceType::Branch { branch } => {
+                format!(
+                    "https://raw.githubusercontent.com/{repo}/refs/heads/{}/{path}",
+                    branch.0
+                )
+            }
+            ReferenceType::Commit { commit } => {
+                format!(
+                    "https://raw.githubusercontent.com/{repo}/{}/{path}",
+                    commit.0
+                )
+            }
+        }
+    }
+}
+
+impl fmt::Display for GithubLink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_url())
+    }
+}
+
+impl fmt::Display for BranchName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Display for CommitHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/descriptions/zksync-root.json
+++ b/descriptions/zksync-root.json
@@ -148,7 +148,11 @@
                 "rust": "AnvilZksync"
             },
             "take_from" : [
-                "https://raw.githubusercontent.com/matter-labs/anvil-zksync/refs/heads/main/etc/errors/anvil.json"
+                {
+                    "repo": "matter-labs/anvil-zksync",
+                    "branch" : "main",
+                    "path" : "etc/errors/anvil.json"
+                }
             ],
             "components" : []
         },


### PR DESCRIPTION
Instead of providing the raw URL, we provide a structured link to repo/ branch or commit / path.