### PR TITLE
fix: clippy warnings for `format` in the generated crate

### DIFF
--- a/crates/zksync-error-codegen/src/backend/rust/files/lib.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/lib.rs
@@ -145,6 +145,7 @@ impl RustBackend {
         let contents = quote! {
             #![allow(non_camel_case_types)]
             #![allow(unused)]
+            #![allow(clippy::uninlined_format_args)]
             #top_level_doc
 
             #imports


### PR DESCRIPTION
Adds `#![allow(clippy::uninlined_format_args)]`