### PR TITLE
feat: completely disable `alloc` for nostd environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       run: cargo fmt --all -- --check
       
     - name: Run clippy lints
-      run: cargo clippy --all-targets --all-features -- -D warnings -A  clippy::collapsible-if
+      run: cargo clippy --all-targets --all-features -- -D warnings
       
     - name: Run tests
       run: cargo test --verbose --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       run: cargo fmt --all -- --check
       
     - name: Run clippy lints
-      run: cargo clippy --all-targets --all-features -- -D warnings -A clippy::large_enum_variant -A clippy::result_large_err -A clippy::doc_overindented_list_items -A clippy::doc_lazy_continuation -A clippy::uninlined_format_args -A dead_code -A clippy::nonminimal_bool -A  clippy::collapsible-if
+      run: cargo clippy --all-targets --all-features -- -D warnings -A  clippy::collapsible-if
       
     - name: Run tests
       run: cargo test --verbose --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,82 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        components: rustfmt, clippy
+        
+    - name: Cache cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+          
+    - name: Check code formatting
+      run: cargo fmt --all -- --check
+      
+    - name: Run clippy lints
+      run: cargo clippy --all-targets --all-features -- -D warnings -A clippy::large_enum_variant -A clippy::result_large_err -A clippy::doc_overindented_list_items -A clippy::doc_lazy_continuation -A clippy::uninlined_format_args -A dead_code -A clippy::nonminimal_bool -A  clippy::collapsible-if
+      
+    - name: Run tests
+      run: cargo test --verbose --all-features
+      
+    - name: Run doc tests
+      run: cargo test --doc --verbose --all-features
+
+  build:
+    name: Build Check
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        
+    - name: Cache cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-build-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+          
+    - name: Build all crates
+      run: cargo build --verbose --all-features
+      
+    - name: Build CLI
+      run: cargo build --verbose -p zksync-error-codegen-cli
+

--- a/crates/zksync-error-codegen-cli/src/error.rs
+++ b/crates/zksync-error-codegen-cli/src/error.rs
@@ -5,5 +5,5 @@ pub enum ApplicationError {
     #[error("Invalid argument `{argument}`: {reason}")]
     InvalidArgument { argument: String, reason: String },
     #[error(transparent)]
-    ProgramError(#[from] ProgramError),
+    ProgramError(#[from] Box<ProgramError>),
 }

--- a/crates/zksync-error-codegen-cli/src/main.rs
+++ b/crates/zksync-error-codegen-cli/src/main.rs
@@ -9,7 +9,7 @@ use error::ApplicationError;
 use zksync_error_codegen::load_and_generate;
 
 fn main_inner(arguments: Arguments) -> Result<(), ApplicationError> {
-    Ok(load_and_generate(arguments.try_into()?)?)
+    Ok(load_and_generate(arguments.try_into()?).map_err(Box::new)?)
 }
 
 fn main() {

--- a/crates/zksync-error-codegen/src/backend/rust/files/cargo.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/cargo.rs
@@ -22,13 +22,15 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["std", "use_anyhow", "use_serde"]
+default = ["std"]
 std = [ "serde/std", "lazy_static/spin_no_std", "anyhow?/std", "strum/std"]
 use_anyhow = ["dep:anyhow"]
 use_serde = ["dep:serde"]
 runtime_documentation = ["dep:serde", "dep:serde_json"]
 serialized_errors = ["dep:serde", "dep:serde_json"]
 packed_errors = ["use_serde"]
+box_wrapped_errors = []
+to_generic = []
 
 [dependencies]
 lazy_static = {{ version = "1.5.0", default-features = false, optional = true }}

--- a/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
@@ -78,7 +78,7 @@ impl RustBackend {
             let component_doc = component_doc(component);
             let from_anyhow =
                     quote! {
-                        #[cfg(feature = "use_anyhow")]
+                        #[cfg(all(feature = "use_anyhow", feature = "std", feature = "to_generic"))]
                         impl From<anyhow::Error> for #component_name {
                             fn from(value: anyhow::Error) -> Self {
                                 let message = format!("{value:#?}");

--- a/crates/zksync-error-codegen/src/backend/rust/files/error/domains.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/error/domains.rs
@@ -127,7 +127,7 @@ impl RustBackend {
                 quote! {
 
                     #[repr(u32)]
-                    #[derive(AsRefStr, Clone, Debug, EnumDiscriminants, Eq, PartialEq)]
+                    #[derive(IntoStaticStr, Clone, Debug, EnumDiscriminants, Eq, PartialEq)]
                     #[strum_discriminants(derive(FromRepr))]
                     #[cfg_attr(feature = "use_serde", derive(serde::Serialize))]
                     #[cfg_attr(feature = "use_serde", derive(serde::Deserialize))]
@@ -139,8 +139,8 @@ impl RustBackend {
                     }
 
                     impl #domain {
-                        pub fn get_name(&self) -> &str {
-                            self.as_ref()
+                        pub fn get_name(&self) -> &'static str {
+                            self.into()
                         }
                     }
                     #(
@@ -199,14 +199,12 @@ impl RustBackend {
 
             #![allow(non_camel_case_types)]
 
-            #[cfg(not(feature = "std"))]
-            use alloc::string::String;
             use core::fmt;
 
             use crate::error::ICustomError;
             use crate::error::IUnifiedError;
             use crate::kind::Kind;
-            use strum_macros::AsRefStr;
+            use strum_macros::IntoStaticStr;
             use strum_macros::EnumDiscriminants;
             use strum_macros::FromRepr;
             #(
@@ -215,7 +213,7 @@ impl RustBackend {
             )*
 
             #[repr(u32)]
-            #[derive(AsRefStr, Clone, Debug, EnumDiscriminants, Eq, PartialEq)]
+            #[derive(IntoStaticStr, Clone, Debug, EnumDiscriminants, Eq, PartialEq)]
             #[cfg_attr(feature = "use_serde", derive(serde::Serialize, serde::Deserialize))]
             pub enum ZksyncError {
                 #( #all_domains( #all_domains ),)*

--- a/crates/zksync-error-codegen/src/backend/rust/files/error/mod_file.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/error/mod_file.rs
@@ -100,7 +100,7 @@ impl RustBackend {
             impl CustomErrorMessageWriter for ZksyncError {
                 #impl_custom_error_message_writer
             }
-            #[cfg(feature = "std")]
+
             pub trait NamedError {
                 fn get_error_name(&self) -> &'static str;
             }

--- a/crates/zksync-error-codegen/src/backend/rust/files/identifier.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/identifier.rs
@@ -14,8 +14,6 @@ impl RustBackend {
 
             #(use crate::error::domains:: #domain_codes ;)*
 
-            #[cfg(not(feature = "std"))]
-            use alloc::{string::String, format};
 
             use crate::error::NamedError;
             use crate::kind::DomainCode;
@@ -89,10 +87,12 @@ impl RustBackend {
         };
 
         let trait_identifying = quote! {
+            #[cfg(feature = "std")]
                 pub trait Identifying {
                     fn get_identifier_repr(&self)-> String;
                 }
 
+            #[cfg(feature = "std")]
                 impl Identifying for Identifier {
                     fn get_identifier_repr(&self) -> String {
                         format!("[{}-{}]", self.kind.get_identifier_repr(), self.code)
@@ -122,6 +122,7 @@ impl RustBackend {
             });
 
             quote! {
+            #[cfg(feature = "std")]
                 impl Identifying for Kind {
                     fn get_identifier_repr(&self) -> String {
                         match self {
@@ -152,8 +153,9 @@ impl RustBackend {
                 });
 
             quote! {
+            #[cfg(feature = "std")]
                 impl NamedError for Identifier {
-                    fn get_error_name(&self) -> String {
+                    fn get_error_name(&self) -> &'static str {
                         match self.kind {
                             #( #match_tokens ),*
                         }
@@ -162,7 +164,7 @@ impl RustBackend {
             }
         };
         let impl_documented = quote! {
-                #[cfg(feature="runtime_documentation")]
+                #[cfg(all(feature="runtime_documentation", feature="std"))]
                 impl crate::documentation::Documented for Identifier {
                     type Documentation = &'static zksync_error_description::ErrorDocumentation;
                     fn get_documentation(&self) -> Result<Option<Self::Documentation>, crate::documentation::DocumentationError> {

--- a/crates/zksync-error-codegen/src/backend/rust/files/lib.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/lib.rs
@@ -19,12 +19,15 @@ impl RustBackend {
             pub use error::IError;
             pub use error::IUnifiedError;
             pub use error::ICustomError;
+            #[cfg(feature="std")]
             pub use error::CustomErrorMessage;
+            pub use error::CustomErrorMessageWriter;
             pub use error::NamedError;
 
             pub(crate) mod identifier;
             pub use identifier::StructuredErrorCode;
             pub use identifier::Identifier;
+            #[cfg(feature = "std")]
             pub use identifier::Identifying;
             pub(crate) mod kind;
             pub use kind::Kind;

--- a/crates/zksync-error-codegen/src/backend/rust/files/lib.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/lib.rs
@@ -117,16 +117,16 @@ impl RustBackend {
 
                         pub use crate:: #macro_name as generic_error;
 
-                        #[cfg(feature = "std")]
+                        #[cfg(all(feature = "std", feature="to_generic"))]
                         pub fn to_generic<T: core::fmt::Display>(err: T) -> #alias_error {
                             GenericError {
-                                message: format!("{}", err),
+                                message: format!("{err}"),
                             }
                         }
-                        #[cfg(feature = "std")]
+                        #[cfg(all(feature = "std", feature="to_generic"))]
                         pub fn to_domain<T: core::fmt::Display>(err: T) -> super::#domain_error_ident {
                             super::#domain_error_ident::#enum_name( GenericError {
-                                message: format!("{}", err),
+                                message: format!("{err}"),
                             })
                         }
                     }

--- a/crates/zksync-error-codegen/src/backend/rust/files/packed.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/packed.rs
@@ -34,8 +34,8 @@ impl RustBackend {
                     self.identifier.clone()
                 }
 
-                fn get_message(&self) -> String {
-                    self.message.clone()
+                fn write_message<W:core::fmt::Write>(&self, writer:&mut W) -> core::fmt::Result {
+                    write!(writer, self.message)
                 }
 
                 fn get_data(&self) -> T {

--- a/crates/zksync-error-codegen/src/description/error.rs
+++ b/crates/zksync-error-codegen/src/description/error.rs
@@ -31,10 +31,10 @@ Note that the line number/column may be reported incorrectly.
         expected: domain::PartialIdentifier,
         domains: Vec<Domain>,
     },
-    #[error("Domain name or code in {} does not match with {expected}", Into::<domain::PartialIdentifier>::into(domain))]
+    #[error("Domain name or code in {} does not match with {expected}", Into::<domain::PartialIdentifier>::into(&**domain))]
     WrongDomain {
         expected: domain::PartialIdentifier,
-        domain: Domain,
+        domain: Box<Domain>,
     },
 
     #[error("No components matching identifier {expected}")]
@@ -51,9 +51,9 @@ Note that the line number/column may be reported incorrectly.
         components: Vec<Component>,
     },
 
-    #[error("Component name or code in {} does not match with {expected}", Into::<component::PartialIdentifier>::into(component))]
+    #[error("Component name or code in {} does not match with {expected}", Into::<component::PartialIdentifier>::into(&**component))]
     WrongComponent {
         expected: component::PartialIdentifier,
-        component: Component,
+        component: Box<Component>,
     },
 }

--- a/crates/zksync-error-codegen/src/description/merge/error.rs
+++ b/crates/zksync-error-codegen/src/description/merge/error.rs
@@ -15,5 +15,5 @@ pub enum MergeError {
     #[error("Conflicting descriptions for component `{0:?}`")]
     ConflictingComponentDefinitions(Box<Component>, Box<Component>),
     #[error("Conflicting error descriptions for errors `{0}` and `{1}`")]
-    ConflictingErrorDescriptions(Error, Error),
+    ConflictingErrorDescriptions(Box<Error>, Box<Error>),
 }

--- a/crates/zksync-error-codegen/src/description/merge/mod.rs
+++ b/crates/zksync-error-codegen/src/description/merge/mod.rs
@@ -196,7 +196,10 @@ impl Mergeable for super::Error {
                 comment: Default::default(),
             })
         } else {
-            Err(MergeError::ConflictingErrorDescriptions(self, other))
+            Err(MergeError::ConflictingErrorDescriptions(
+                Box::new(self),
+                Box::new(other),
+            ))
         }
     }
 }

--- a/crates/zksync-error-codegen/src/description/normalization/mod.rs
+++ b/crates/zksync-error-codegen/src/description/normalization/mod.rs
@@ -45,7 +45,7 @@ pub fn produce_root(
             if &Into::<domain::PartialIdentifier>::into(domain) == domain_binding {
                 Ok(domain.normalize(&()))
             } else {
-                let domain = domain.clone();
+                let domain = Box::new(domain.clone());
                 Err(FileFormatError::WrongDomain {
                     expected: domain_binding.clone(),
                     domain,
@@ -71,7 +71,7 @@ pub fn produce_root(
             if &Into::<component::PartialIdentifier>::into(component) == component_binding {
                 Ok(component.normalize(domain_binding))
             } else {
-                let component = component.clone();
+                let component = Box::new(component.clone());
                 Err(FileFormatError::WrongComponent {
                     expected: component_binding.clone(),
                     component,

--- a/crates/zksync-error-codegen/src/loader/error.rs
+++ b/crates/zksync-error-codegen/src/loader/error.rs
@@ -18,7 +18,7 @@ pub enum LoadError {
     #[error("Error loading errors from {origin}: {inner}")]
     FileFormatError {
         origin: Link,
-        inner: FileFormatError,
+        inner: Box<FileFormatError>,
     },
 
     #[error(transparent)]
@@ -36,7 +36,10 @@ pub enum LoadError {
     #[error(
         "Circular dependency detected: file {trigger} attempted to reference {visited} which was already visited."
     )]
-    CircularDependency { trigger: Link, visited: Link },
+    CircularDependency {
+        trigger: Box<Link>,
+        visited: Box<Link>,
+    },
 
     #[error("Failed to import a file {address}: {inner}")]
     TakeFrom {

--- a/crates/zksync-error-codegen/src/loader/mod.rs
+++ b/crates/zksync-error-codegen/src/loader/mod.rs
@@ -67,7 +67,10 @@ fn load_single_fragment(
                 overridden,
             })
         }
-        Err(inner) => Err(LoadError::FileFormatError { origin, inner }),
+        Err(inner) => Err(LoadError::FileFormatError {
+            origin,
+            inner: Box::new(inner),
+        }),
     }
 }
 
@@ -110,8 +113,8 @@ pub fn load_dependent_component(
             let dependency = link::parse(dependency)?;
             if !visited.insert(dependency.clone()) {
                 return Err(LoadError::CircularDependency {
-                    trigger: origin.clone(),
-                    visited: dependency,
+                    trigger: Box::new(origin.clone()),
+                    visited: Box::new(dependency),
                 });
             } else {
                 let new_fragment_result = load_single_fragment(&dependency, binding, new_context)?;

--- a/crates/zksync-error-codegen/tests/loader/build_mode_integration.rs
+++ b/crates/zksync-error-codegen/tests/loader/build_mode_integration.rs
@@ -16,7 +16,6 @@ use zksync_error_model::link::{
     github::{BranchName, GithubLink},
 };
 
-
 #[test]
 fn test_normal_to_reproducible_workflow() {
     let temp_dir = tempdir().expect("Failed to create temp dir");

--- a/crates/zksync-error-codegen/tests/loader/build_modes.rs
+++ b/crates/zksync-error-codegen/tests/loader/build_modes.rs
@@ -266,7 +266,8 @@ fn test_normal_mode_updates_existing_lock_file() {
                 "test-org/test-repo".to_string(),
                 "errors/common.json".to_string(),
                 BranchName("main".to_string()),
-            ))).is_some(),
+            )))
+            .is_some(),
         "Existing dependency should be preserved"
     );
 }

--- a/crates/zksync-error-codegen/tests/loader/override_lock_behavior_simple.rs
+++ b/crates/zksync-error-codegen/tests/loader/override_lock_behavior_simple.rs
@@ -25,40 +25,53 @@ fn test_override_vs_no_override() {
             }
         ]
     }"#;
-    
+
     let root_file = NamedTempFile::new().expect("Failed to create temp file");
     fs::write(root_file.path(), root_content).expect("Failed to write to temp file");
-    
+
     let root_link = Link::FileLink {
         path: root_file.path().to_string_lossy().to_string(),
     };
-    
+
     // Test 1: NoLock context with no overrides (should work)
     let mut context = ResolutionContext::NoLock {
-        overrides: Remapping { map: BTreeMap::new() },
+        overrides: Remapping {
+            map: BTreeMap::new(),
+        },
     };
-    
+
     let result = load_dependent_component(root_link.clone(), &mut context);
-    assert!(result.is_ok(), "Self-contained file should load successfully");
-    
+    assert!(
+        result.is_ok(),
+        "Self-contained file should load successfully"
+    );
+
     if let Ok(fragments) = result {
         assert_eq!(fragments.len(), 1, "Should have exactly one fragment");
         assert_eq!(fragments[0].root.domains.len(), 1, "Should have one domain");
-        assert_eq!(fragments[0].root.domains[0].domain_name, "SelfContainedRoot");
+        assert_eq!(
+            fragments[0].root.domains[0].domain_name,
+            "SelfContainedRoot"
+        );
     }
-    
+
     // Test 2: LockOrPopulate context with no overrides (should also work)
     let mut context2 = ResolutionContext::LockOrPopulate {
-        overrides: Remapping { map: BTreeMap::new() },
+        overrides: Remapping {
+            map: BTreeMap::new(),
+        },
         lock: zksync_error_codegen::loader::dependency_lock::DependencyLock::new(),
     };
-    
+
     let result2 = load_dependent_component(root_link, &mut context2);
-    assert!(result2.is_ok(), "Self-contained file should load successfully in LockOrPopulate mode");
+    assert!(
+        result2.is_ok(),
+        "Self-contained file should load successfully in LockOrPopulate mode"
+    );
 }
 
 // Test that demonstrates the feature works: override changes resolution
-#[test]  
+#[test]
 fn test_override_changes_resolution() {
     // Create two different files with different domain names
     let original_content = r#"{
@@ -75,7 +88,7 @@ fn test_override_changes_resolution() {
             }
         ]
     }"#;
-    
+
     let override_content = r#"{
         "domains": [
             {
@@ -90,46 +103,60 @@ fn test_override_changes_resolution() {
             }
         ]
     }"#;
-    
+
     let original_file = NamedTempFile::new().expect("Failed to create temp file");
     fs::write(original_file.path(), original_content).expect("Failed to write to temp file");
-    
+
     let override_file = NamedTempFile::new().expect("Failed to create temp file");
     fs::write(override_file.path(), override_content).expect("Failed to write to temp file");
-    
+
     let original_link = Link::FileLink {
         path: original_file.path().to_string_lossy().to_string(),
     };
-    
+
     // Test without override - should get original domain
     let mut context1 = ResolutionContext::NoLock {
-        overrides: Remapping { map: BTreeMap::new() },
+        overrides: Remapping {
+            map: BTreeMap::new(),
+        },
     };
-    
+
     let result1 = load_dependent_component(original_link.clone(), &mut context1);
     assert!(result1.is_ok(), "Should load original file");
     if let Ok(fragments) = result1 {
-        assert!(fragments[0].root.domains.iter().any(|d| d.domain_name == "OriginalDomain"), 
-                "Should have original domain");
+        assert!(
+            fragments[0]
+                .root
+                .domains
+                .iter()
+                .any(|d| d.domain_name == "OriginalDomain"),
+            "Should have original domain"
+        );
     }
-    
+
     // Test with override - should get overridden domain
     let mut overrides = BTreeMap::new();
     overrides.insert(
         original_link.clone(),
         Link::FileLink {
             path: override_file.path().to_string_lossy().to_string(),
-        }
+        },
     );
-    
+
     let mut context2 = ResolutionContext::NoLock {
         overrides: Remapping { map: overrides },
     };
-    
+
     let result2 = load_dependent_component(original_link, &mut context2);
     assert!(result2.is_ok(), "Should load overridden file");
     if let Ok(fragments) = result2 {
-        assert!(fragments[0].root.domains.iter().any(|d| d.domain_name == "OverriddenDomain"), 
-                "Should have overridden domain");
+        assert!(
+            fragments[0]
+                .root
+                .domains
+                .iter()
+                .any(|d| d.domain_name == "OverriddenDomain"),
+            "Should have overridden domain"
+        );
     }
 }

--- a/crates/zksync-error-model/src/error.rs
+++ b/crates/zksync-error-model/src/error.rs
@@ -19,7 +19,7 @@ Domains:
 {1:#?}
  "
     )]
-    NonUniqueDomains(DomainMetadata, DomainMetadata),
+    NonUniqueDomains(Box<DomainMetadata>, Box<DomainMetadata>),
     #[error(
         "At least two components are assigned the same code, name, or identifier.
 Components:
@@ -30,7 +30,11 @@ Parent domain:
 {2:#?}
  "
     )]
-    NonUniqueComponents(ComponentMetadata, ComponentMetadata, DomainMetadata),
+    NonUniqueComponents(
+        Box<ComponentMetadata>,
+        Box<ComponentMetadata>,
+        Box<DomainMetadata>,
+    ),
     #[error(
         "At least two errors of a single component are assigned the same name of code.
 Errors:
@@ -45,9 +49,9 @@ Parent domain:
  "
     )]
     NonUniqueErrors(
-        ErrorDescription,
-        ErrorDescription,
-        ComponentMetadata,
-        DomainMetadata,
+        Box<ErrorDescription>,
+        Box<ErrorDescription>,
+        Box<ComponentMetadata>,
+        Box<DomainMetadata>,
     ),
 }

--- a/crates/zksync-error-model/src/validator.rs
+++ b/crates/zksync-error-model/src/validator.rs
@@ -49,8 +49,8 @@ fn ensure_unique_domains(model: &Model) -> Result<(), ModelValidationError> {
         }))
     {
         Err(ModelValidationError::NonUniqueDomains(
-            d1.meta.as_ref().clone(),
-            d2.meta.as_ref().clone(),
+            Box::new(d1.meta.as_ref().clone()),
+            Box::new(d2.meta.as_ref().clone()),
         ))
     } else {
         Ok(())
@@ -67,9 +67,9 @@ fn ensure_unique_components(domain: &DomainDescription) -> Result<(), ModelValid
             }))
     {
         Err(ModelValidationError::NonUniqueComponents(
-            c1.meta.as_ref().clone(),
-            c2.meta.as_ref().clone(),
-            domain.meta.as_ref().clone(),
+            Box::new(c1.meta.as_ref().clone()),
+            Box::new(c2.meta.as_ref().clone()),
+            Box::new(domain.meta.as_ref().clone()),
         ))
     } else {
         Ok(())
@@ -81,10 +81,10 @@ fn ensure_unique_errors(component: &ComponentDescription) -> Result<(), ModelVal
         .or(find_duplicate_by(component.errors.iter(), |e| e.code))
     {
         Err(ModelValidationError::NonUniqueErrors(
-            error1.clone(),
-            error2.clone(),
-            component.meta.as_ref().clone(),
-            component.meta.domain.as_ref().clone(),
+            Box::new(error1.clone()),
+            Box::new(error2.clone()),
+            Box::new(component.meta.as_ref().clone()),
+            Box::new(component.meta.domain.as_ref().clone()),
         ))
     } else {
         Ok(())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+profile = "default"
+channel = "1.88.0"


### PR DESCRIPTION
Some APIs were augmented: the former versions are still available with std enabled, with `alloc` printing accepts an explicit instance of `Write` to prevent heap allocations.