### PR TITLE
Depending on a feature flag, wrap inner errors in Box or not

### DIFF
--- a/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
+++ b/crates/zksync-error-codegen/src/backend/rust/files/error/definitions.rs
@@ -205,6 +205,10 @@ impl RustBackend {
             use strum_macros::FromRepr;
             use crate::error::domains::*;
 
+            #[cfg(all(feature="std", feature="box_wrapped_errors"))]
+            pub type Wrapped<E> = Box<E>;
+            #[cfg(not(feature="std"))]
+            pub type Wrapped<E> = E;
 
             #( #definitions )*
         };

--- a/crates/zksync-error-codegen/src/loader/builder/mod.rs
+++ b/crates/zksync-error-codegen/src/loader/builder/mod.rs
@@ -418,7 +418,7 @@ fn bind_error_types(model: &mut Model) {
         match language {
             "rust" => Some((
                 language.to_owned(),
-                format!("Box<{binding}>").as_str().into(),
+                format!("Wrapped<{binding}>").as_str().into(),
             )),
             _ => None,
         }

--- a/descriptions/zksync-root.json
+++ b/descriptions/zksync-root.json
@@ -1,7 +1,12 @@
 {
     "take_from": [
         "zksync-error://types/common.json",
-        "zksync-error://types/zksync-specific.json"
+        "zksync-error://types/zksync-specific.json",
+        {
+            "repo": "matter-labs/anvil-zksync",
+            "branch" : "main",
+            "path" : "etc/errors/anvil.json"
+        }
     ],
     "types": [],
     "domains": [
@@ -138,23 +143,6 @@
                     "errors" : []
                 }
             ]
-        },
-        {
-            "domain_name": "AnvilZKsync",
-            "domain_code": 5,
-            "identifier_encoding": "anvil_zksync",
-            "description": "Errors originating in Anvil for ZKsync.",
-            "bindings": {
-                "rust": "AnvilZksync"
-            },
-            "take_from" : [
-                {
-                    "repo": "matter-labs/anvil-zksync",
-                    "branch" : "main",
-                    "path" : "etc/errors/anvil.json"
-                }
-            ],
-            "components" : []
         },
         {
             "domain_name": "Hardhat",


### PR DESCRIPTION
It is useful to disable Box for nostd environment.